### PR TITLE
fix h3 title after override style

### DIFF
--- a/front/src/app/shared/footer/footer.component.html
+++ b/front/src/app/shared/footer/footer.component.html
@@ -2,11 +2,11 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6 presta-mt-7">
-        <h2 class="text-white">PrestaPoints</h2>
+        <h3 class="text-white">PrestaPoints</h3>
         <p>PrestaPoints permet à des passionnés de partager leur savoir-faire avec des novices à travers des ateliers et d'obtenir des réductions dans des grandes enseignes</p>
       </div>
       <div class="col-md-4">
-        <h3 class="text-white presta-mt-8 presta-ml-17">Réseaux sociaux</h3>
+        <h4 class="text-white presta-mt-8 presta-ml-17">Réseaux sociaux</h4>
             <div class="social-media-list presta-mt-5 presta-ml-20">
               <a href="#" class="nav-link"><i class="bi bi-facebook fs-3"></i></a>
               <a href="#" class="nav-link"><i class="bi bi-twitter fs-3"></i></a>
@@ -18,7 +18,7 @@
     <div class="informations">
       <div class="row">
         <div class="col-md-4">
-          <h3 class="text-white">Notre offre</h3>
+          <h4 class="text-white">Notre offre</h4>
             <div>
               <a href="#" class="nav-link">Par univers</a>
             </div>
@@ -33,7 +33,7 @@
             </div>
         </div>
         <div class="col-md-4">
-          <h3 class="text-white">PrestaPoints</h3>
+          <h4 class="text-white">PrestaPoints</h4>
             <div>
               <a href="#" class="nav-link">Notre mission</a>
             </div>
@@ -48,7 +48,7 @@
             </div>
         </div>
         <div class="col-md-4">
-            <h3 class="text-white">Liens utiles</h3>
+            <h4 class="text-white">Liens utiles</h4>
               <div>
                 <a href="#" class="nav-link">FAQ</a>
               </div>
@@ -66,7 +66,7 @@
     </div>
   <hr>
     <div class="text-center">
-      <h3>&copy; 2023 PrestaPoints. Tous droits réservés.</h3>
+      <h4>&copy; 2023 PrestaPoints. Tous droits réservés.</h4>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
le footer cassait après le merge de US02_card, les tailles des titres étaient trop gros. Soit ce fixe est bon, soit il faut fixer le fichier style. A choisir. 